### PR TITLE
README.md and build-linux.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Linux Vcash Install Script :penguin:
 
-
+THIS IS A FORK FROM THE ORIGINAL SCRIPT BUILT BY A THIRD PARTY.
 
 ## Warning !
 Please backup your existing wallet files (~/.Vcash/data/ folder).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Vcash Install / Update Scripts
+# Linux Vcash Install Script
 
 ## Warning !
 Please backup your existing wallet files (~/.Vcash/data/ folder).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ sudo pacman -S base-devel openssl curl git screen wget
 ```
 #### Gentoo
 ```
-emerge --ask openssl curl git screen wget
+sudo emerge --ask openssl curl git screen wget
 ```
 
 #### Raspbian

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 Please backup your existing wallet files (~/.Vcash/data/ folder).
 I can't be responsible if you break something.
 
-## Req.
+## Requirements
 
 #### GNU/Linux
-GCC/G++ >= 4.8.* / git / screen / curl. On low-spec hardware, don't forget to increase the swap space (min 1024MB) to avoid 'Virtual memory exhausted: Cannot allocate memory' during the build process.
+**GCC/G++ >= 4.8.*** / git / screen / curl. On low-spec hardware, don't forget to increase the swap space (min 1024MB) to avoid 'Virtual memory exhausted: Cannot allocate memory' during the build process.
 
 #### Debian / Ubuntu / Raspbian
 ```
-sudo apt-get install build-essential openssl curl git screen
+sudo apt-get install build-essential openssl curl git screen wget
 ```
 
 #### Arch Linux

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ I can't be responsible if you break something.
 
 ## Requirements
 
-#### GNU/Linux
-**GCC/G++ >= 4.8.*** / git / screen / curl. On low-spec hardware, don't forget to increase the swap space (min 1024MB) to avoid 'Virtual memory exhausted: Cannot allocate memory' during the build process.
+#### GNU / Linux
+GCC/G++ >= **4.8.*** / git / screen / curl. On low-spec hardware, don't forget to increase the swap space (min 1024MB) to avoid 'Virtual memory exhausted: Cannot allocate memory' during the build process.
 
 #### Debian / Ubuntu / Raspbian
 ```

--- a/README.md
+++ b/README.md
@@ -79,23 +79,23 @@ CTRL+X and press Y.
 
 Create swap file:
 ```
-dd if=/dev/zero of=/PATH/FILENAME bs=1024 count=SIZE
+dd if=/dev/zero of=/path/filename bs=1M count=1024
 ```
 Set permissions:
 ```
-chmod 600 /PATH/FILENAME
+chmod 600 /path/filename
 ```
 Format to swap:
 ```
-mkswap /PATH/FILENAME
+mkswap /path/filename
 ```
 Activate the swap file:
 ```
-swapon /PATH/FILENAME
+swapon /path/filename
 ```
 Add this line to /etc/fstab:
 ```
-/PATH/FILENAME none swap sw 0 0
+/path/filename none swap sw 0 0
 ```
 
 ## Install / Update

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ sudo /etc/init.d/dphys-swapfile stop
 sudo /etc/init.d/dphys-swapfile start
 ```
 
-#### Arch Linux
+#### Arch Linux / Gentoo
 
 Create swap file:
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Linux
 
-Linux Install Vcash Script :penguin:
+Linux Vcash Install Script :penguin:
+
+
 
 ## Warning !
 Please backup your existing wallet files (~/.Vcash/data/ folder).

--- a/README.md
+++ b/README.md
@@ -11,12 +11,16 @@ GCC/G++ >= 4.8.* / git / screen / curl. On low-spec hardware, don't forget to in
 
 #### Debian / Ubuntu / Raspbian
 ```
-sudo apt-get install build-essential openssl curl git-core screen -y
+sudo apt-get install build-essential openssl curl git screen
 ```
 
 #### Arch Linux
 ```
-sudo pacman -S base-devel openssl curl git screen wget -y
+sudo pacman -S base-devel openssl curl git screen wget
+```
+#### Gentoo
+```
+emerge --ask openssl curl git screen wget
 ```
 
 #### Raspbian

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Activate the swap file:
 ```
 swapon /PATH/FILENAME
 ```
-Add this line to /etc/fstab
+Add this line to /etc/fstab:
 ```
 /PATH/FILENAME none swap sw 0 0
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ GCC/G++ >= **4.8.***. On low-spec hardware, don't forget to increase the swap sp
 ```
 sudo apt-get install build-essential openssl curl git screen wget
 ```
-
 #### Arch Linux
 ```
 sudo pacman -S base-devel openssl curl git screen wget
@@ -75,6 +74,29 @@ Add the folowing entry:
 /swapfile none swap defaults 0 0
 ```
 CTRL+X and press Y.
+
+#### Ubuntu / Debian
+
+Create swap file:
+```
+dd if=/dev/zero of=/PATH/FILENAME bs=1024 count=SIZE
+```
+Set permissions:
+```
+chmod 600 /PATH/FILENAME
+```
+Format to swap:
+```
+mkswap /PATH/FILENAME
+```
+Activate the swap file:
+```
+swapon /PATH/FILENAME
+```
+Add this line to /etc/fstab
+```
+/PATH/FILENAME swap swap sw 0 0
+```
 
 ## Install / Update
 As user (fresh ssh login as user, not su switch to user from the root account):

--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ sudo emerge --ask openssl curl git screen wget
 ## Swap
 
 #### Raspbian
-Be sure to have enough swap to avoid 'Virtual memory exhausted: Cannot allocate memory'.
-Raspbian default swap size is 100MB, please increase the size before building.
+Be sure to have enough swap to avoid "Virtual memory exhausted: Cannot allocate memory".
 
 Check swap size:
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ I can't be responsible if you break something.
 ## Requirements
 
 #### GNU / Linux
-GCC/G++ >= **4.8.***. Don't forget to increase the swap space with a minimum of 1024MB to avoid "Virtual memory exhausted: Cannot allocate memory" during the build process on ARM like developer boards or machines with less then X GB of memory.
+GCC version **4.8.***. Don't forget to increase the swap space with a minimum of 1024MB to avoid "Virtual memory exhausted: Cannot allocate memory" during the build process on ARM like developer boards or machines with less then X GB of memory.
 
 Note: GCC version 4.9.2 is confirmed to work on a raspberry pi 2/3 running raspbian jessie.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Linux Vcash Install Script
+# Linux
+
+Linux Install Vcash Script :penguin:
 
 ## Warning !
 Please backup your existing wallet files (~/.Vcash/data/ folder).

--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ sudo emerge --ask openssl curl git screen wget
 ## Swap
 
 #### Raspbian
-Be sure to have enough swap to avoid "Virtual memory exhausted: Cannot allocate memory".
+Be sure to have enough swap space to avoid "Virtual memory exhausted: Cannot allocate memory".
 
 Check swap size:
 ```
 free -m
 ```
 
-Example with 1024MB as swap size:
+Set 1024MB as swap size:
 ```
 sudo nano /etc/dphys-swapfile
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ I can't be responsible if you break something.
 ## Requirements
 
 #### GNU / Linux
-GCC/G++ >= **4.8.***. Don't forget to increase the swap space (min 1024MB) to avoid "Virtual memory exhausted: Cannot allocate memory" during the build process on ARM like developer boards or machines with less then X GB of memory.
+GCC/G++ >= **4.8.***. Don't forget to increase the swap space with a minimum of 1024MB to avoid "Virtual memory exhausted: Cannot allocate memory" during the build process on ARM like developer boards or machines with less then X GB of memory.
 
 Note: GCC version 4.9.2 is confirmed to work on a raspberry pi 2/3 running raspbian jessie.
 

--- a/README.md
+++ b/README.md
@@ -2,28 +2,33 @@
 
 ## Warning !
 Please backup your existing wallet files (~/.Vcash/data/ folder).
-I can't be responsible if you broke something.
+I can't be responsible if you break something.
 
 ## Req.
 
 #### GNU/Linux
-GCC/G++ >= 4.8.* / git / screen / curl. On low-spec hardware, don't forget to increase the SWAP (min 1024MB) to avoid the 'Virtual memory exhausted: Cannot allocate memory' during the build process.
+GCC/G++ >= 4.8.* / git / screen / curl. On low-spec hardware, don't forget to increase the swap space (min 1024MB) to avoid 'Virtual memory exhausted: Cannot allocate memory' during the build process.
 
 #### Debian / Ubuntu / Raspbian
 ```
 sudo apt-get install build-essential openssl curl git-core screen -y
 ```
 
-#### Raspbian
-Be sure to have enough Swap to avoid 'Virtual memory exhausted: Cannot allocate memory'.
-Raspbian default Swap size is 100mb, please increase the size before building.
+#### Arch Linux
+```
+sudo pacman -S base-devel openssl curl git screen wget -y
+```
 
-Check Swap size:
+#### Raspbian
+Be sure to have enough swap to avoid 'Virtual memory exhausted: Cannot allocate memory'.
+Raspbian default swap size is 100MB, please increase the size before building.
+
+Check swap size:
 ```
 free -m
 ```
 
-Example with 1024mb as Swap size:
+Example with 1024MB as swap size:
 ```
 sudo nano /etc/dphys-swapfile
 ```
@@ -37,17 +42,47 @@ sudo /etc/init.d/dphys-swapfile stop
 sudo /etc/init.d/dphys-swapfile start
 ```
 
+#### Arch Linux
+
+Create swap file:
+```
+sudo fallocate -l 1024M /swapfile
+```
+Set permissions:
+```
+sudo chmod 600 /swapfile
+```
+Format to swap:
+```
+sudo mkswap /swapfile
+```
+Activate swap file:
+```
+sudo swapon /swapfile
+```
+Open fstab in nano:
+```
+sudo nano /etc/fstab
+```
+Add the folowing entry:
+```
+/swapfile none swap defaults 0 0
+```
+CTRL+X and press Y.
+
 ## Install / Update
 As user (fresh ssh login as user, not su switch to user from the root account):
 ```
-bash < <(curl -s  https://raw.githubusercontent.com/john-connor/vcash-scripts/master/build-linux.sh)
+git clone https://github.com/john-connor/vcash-scripts
+cd vcash-scripts
+./build-linux.sh
 ```
 The script will auto launch vcashd at the end.
 Resume the screen session with:
 ```
 screen -x vcashd
 ```
-Ctrl-a Ctrl-d to detach
+Ctrl-A Ctrl-D to detach.
 
 ## Launch
 Be sure there's no vcashd running before !
@@ -70,7 +105,7 @@ Add this entry (edited with your username):
 ```
 @reboot pgrep vcashd > /dev/null || cd /home/your_username/vcash && screen -d -S vcashd -m ./vcashd
 ```
-save & check crontab:
+Save & check crontab:
 ```
 crontab -l
 ```

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Linux Vcash Install Script :penguin:
 
-THIS IS A FORK FROM THE ORIGINAL SCRIPT BUILT BY A THIRD PARTY.
-
 ## Warning !
 Please backup your existing wallet files (~/.Vcash/data/ folder).
 I can't be responsible if you break something.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ I can't be responsible if you break something.
 #### GNU / Linux
 GCC/G++ >= **4.8.***. On low-spec hardware, don't forget to increase the swap space (min 1024MB) to avoid 'Virtual memory exhausted: Cannot allocate memory' during the build process.
 
+Note: GCC version 4.9.2 is confirmed to work on a raspberry pi running raspbian jessie.
+
 #### Debian / Ubuntu / Raspbian
 ```
 sudo apt-get install build-essential openssl curl git screen wget

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ I can't be responsible if you break something.
 ## Requirements
 
 #### GNU / Linux
-GCC/G++ >= **4.8.***. Don't forget to increase the swap space (min 1024MB) to avoid 'Virtual memory exhausted: Cannot allocate memory' during the build process on ARM like developer boards or machines with less then X GB of memory.
+GCC/G++ >= **4.8.***. Don't forget to increase the swap space (min 1024MB) to avoid "Virtual memory exhausted: Cannot allocate memory" during the build process on ARM like developer boards or machines with less then X GB of memory.
 
 Note: GCC version 4.9.2 is confirmed to work on a raspberry pi 2/3 running raspbian jessie.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ I can't be responsible if you break something.
 ## Requirements
 
 #### GNU / Linux
-GCC/G++ >= **4.8.*** / git / screen / curl. On low-spec hardware, don't forget to increase the swap space (min 1024MB) to avoid 'Virtual memory exhausted: Cannot allocate memory' during the build process.
+GCC/G++ >= **4.8.***. On low-spec hardware, don't forget to increase the swap space (min 1024MB) to avoid 'Virtual memory exhausted: Cannot allocate memory' during the build process.
 
 #### Debian / Ubuntu / Raspbian
 ```

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ I can't be responsible if you break something.
 ## Requirements
 
 #### GNU / Linux
-GCC/G++ >= **4.8.***. On low-spec hardware, don't forget to increase the swap space (min 1024MB) to avoid 'Virtual memory exhausted: Cannot allocate memory' during the build process.
+GCC/G++ >= **4.8.***. Don't forget to increase the swap space (min 1024MB) to avoid 'Virtual memory exhausted: Cannot allocate memory' during the build process on ARM like developer boards or machines with less then X GB of memory.
 
-Note: GCC version 4.9.2 is confirmed to work on a raspberry pi running raspbian jessie.
+Note: GCC version 4.9.2 is confirmed to work on a raspberry pi 2/3 running raspbian jessie.
 
 #### Debian / Ubuntu / Raspbian
 ```

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ sudo pacman -S base-devel openssl curl git screen wget
 sudo emerge --ask openssl curl git screen wget
 ```
 
+## Swap
+
 #### Raspbian
 Be sure to have enough swap to avoid 'Virtual memory exhausted: Cannot allocate memory'.
 Raspbian default swap size is 100MB, please increase the size before building.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ swapon /PATH/FILENAME
 ```
 Add this line to /etc/fstab
 ```
-/PATH/FILENAME swap swap sw 0 0
+/PATH/FILENAME none swap sw 0 0
 ```
 
 ## Install / Update

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -90,7 +90,7 @@ make -j$job depend && make -j$job && make install
 # DB
 cd $VCASH_ROOT
 wget --no-check-certificate "https://download.oracle.com/berkeley-db/db-6.1.29.NC.tar.gz"
-echo "e3404de2e111e95751107d30454f569be9ec97325d5ea302c95a058f345dfe0e 6.1.29.NC.tar.gz" | sha256sum -c
+echo "e3404de2e111e95751107d30454f569be9ec97325d5ea302c95a058f345dfe0e db-6.1.29.NC.tar.gz" | sha256sum -c
 tar -xzf db-6.1.29.NC.tar.gz
 echo "Compile & install db in deps folder" | tee -a $VCASH_ROOT/build.log
 cd db-6.1.29.NC/build_unix/


### PR DESCRIPTION
README.md: Changed format, grammar and style. Included build instructions for Arch Linux and Gentoo. Updated swap instructions to include Ubuntu and Debian.

build-linux.sh: Found missing characters in file name checksum for Berkley DB which caused a non-fatal error during build.